### PR TITLE
Fix warning: PHP Deprecated Warning – yii\base\ErrorException

### DIFF
--- a/controllers/ImagesController.php
+++ b/controllers/ImagesController.php
@@ -35,7 +35,7 @@ class ImagesController extends Controller
      * @param $alias
      *
      */
-    public function actionImageByItemAndAlias($item='', $dirtyAlias)
+    public function actionImageByItemAndAlias($dirtyAlias, $item='')
     {
         $dotParts = explode('.', $dirtyAlias);
         if(!isset($dotParts[1])){


### PR DESCRIPTION
Optional parameter $item declared before required parameter $dirtyAlias is implicitly treated as a required parameter

PHP 8.3.17 (cli) (built: Feb 11 2025 22:39:26) (ZTS Visual C++ 2019 x64)
Copyright (c) The PHP Group
Zend Engine v4.3.17, Copyright (c) Zend Technologies

